### PR TITLE
align deps with most recent clojure version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: clojure
-lein: lein2
+lein: lein
 script:
-- lein2 midje
-notifications:
-  email:
-    recipients:
-      - chris@helpshift.com
-      - bg@helpshift.com
+- lein midje

--- a/lein/src/leiningen/hydrox/setup.clj
+++ b/lein/src/leiningen/hydrox/setup.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.reader.edn :as edn]
             [clojure.tools.reader.impl.commons :as common]
             [clojure.tools.reader.impl.utils :as utils]
+            [clojure.tools.reader.impl.errors :as read-err]
             [clojure.tools.reader.reader-types :as reader]))
 
 (defn read-keyword
@@ -10,7 +11,7 @@
     (if-not (utils/whitespace? ch)
       (let [token (#'edn/read-token reader ch)]
         (keyword token))
-      (reader/reader-error reader "Invalid token: :"))))
+      (read-err/reader-error reader "Invalid token: :"))))
 
 (defn patch-read-keyword []
   (alter-var-root #'clojure.tools.reader.edn/read-keyword

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/helpshift/hydrox"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [im.chit/jai  "0.2.10"]
                  [im.chit/hara.data      "2.2.17"]
                  [im.chit/hara.io.watch  "2.2.17"]

--- a/project.clj
+++ b/project.clj
@@ -38,10 +38,10 @@
                   :link {:auto-tag    true
                          :auto-number  true}}
 
-  :profiles {:dev {:dependencies [[midje "1.7.0"]
+  :profiles {:dev {:dependencies [[midje "1.9.7"]
                                   [compojure "1.4.0"]
                                   [ring "1.4.0"]
                                   [clj-http "1.1.2"]]
-                   :plugins [[lein-midje "3.1.3"]
+                   :plugins [[lein-midje "3.2.1"]
                              [lein-ancient "0.6.7"]
                              [lein-hydrox "0.1.14"]]}})


### PR DESCRIPTION
`reader-error` function was moved to a new namespace, causing problems when hydrox is used in projects that use clojure 1.10.0. I ran `lein hydrox` on this project using clojure 1.10.0 and got no errors.